### PR TITLE
BugFix: Allow egress between vpc endpoints and sagemaker studio instance

### DIFF
--- a/templates/vpc_template.yaml
+++ b/templates/vpc_template.yaml
@@ -92,7 +92,7 @@ Resources:
       FromPort: 443
       ToPort: 443
       GroupId: !Ref VPCEndpointSecurityGroup
-      SourceSecurityGroupId: !Ref VPCEndpointSecurityGroup
+      SourceSecurityGroupId: !Ref SecurityGroup
 
   VPCEndpointS3:
     Type: AWS::EC2::VPCEndpoint


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Not sure why previous commit made the change but ENI's associated with VPC endpoints must allow traffic from security -group attached to studio instances

Without this studio cannot make call to sagemaker/cloudwatch etc.. With out making call to sagemaker, studio users cannot create new kernels

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
